### PR TITLE
previous results tables update after edit (storing all results global…

### DIFF
--- a/src/components/PreviousResults.vue
+++ b/src/components/PreviousResults.vue
@@ -33,7 +33,6 @@ const ex1PerPage = ref(10)
 const ex1Rows = ref(100)
 
 const testMessage = ref('')
-const results = ref([])
 
 onMounted(() => {
   getResults()
@@ -51,7 +50,7 @@ async function getResults() {
   const data = await response.json()
   //console.log(data)
   let allResults = data.all_results
-  results.value = formatResults(allResults)
+  store.allResults = formatResults(allResults)
   //console.log(results.value)
 }
 
@@ -86,7 +85,8 @@ async function getResult() {
       <h3>Previous results</h3>
       <Table
         @loadResult="loadResult"
-        :results="results"
+        @loadResults="getResults"
+        :results="store.allResults"
         :headers="headers"
         buttonText="Remove"
         :removable="true"

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -6,7 +6,12 @@ import { API_URL } from '../api'
 Utrecht University within the Software Project course.
 © Copyright Utrecht University (Department of Information and Computing Sciences)*/
 
-const emit = defineEmits(['loadResult', 'loadMore', 'paginationSort'])
+const emit = defineEmits([
+  'loadResult',
+  'loadResults',
+  'loadMore',
+  'paginationSort',
+])
 const props = defineProps({
   overview: Boolean,
   results: Array,
@@ -56,6 +61,7 @@ async function editEntry() {
   }
   fetch(API_URL + props.serverFile2, requestOptions).then(() => {
     console.log('Item edited succesfully')
+    emit('loadResults')
   })
   newName.value = ''
   newTags.value = ''

--- a/src/store.js
+++ b/src/store.js
@@ -14,7 +14,11 @@ function mockResult() {
   return { id: 0, name: 'computation1', result: [mock, mock] }
 }
 
-const store = reactive({ currentResults: [mockResult()], queue: [] })
+const store = reactive({
+  currentResults: [mockResult()],
+  queue: [],
+  allResults: [],
+})
 
 // Add a new result to the global current shown results state
 function addResult(result) {


### PR DESCRIPTION
…ly now)

can instantly see edited results
we use allResults in the store to get and set the previous results now